### PR TITLE
fix: remove js maps from build

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     }
   },
   "files": [
-    "dist/*"
+    "dist/index.d.ts",
+    "dist/index.js"
   ],
   "scripts": {
     "build": "pnpm build:clean && pnpm _build:node && pnpm _build:browser",

--- a/package.json
+++ b/package.json
@@ -56,5 +56,5 @@
     "typedoc": "^0.23.20",
     "typescript": "4.8.2"
   },
-  "version": "1.19.4-exodus.0"
+  "version": "1.19.4-exodus.1"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "moduleResolution": "node",
     "noImplicitAny": true,
     "outDir": "./dist",
-    "sourceMap": true,
+    "sourceMap": false,
     "strict": true,
     "target": "es2020",
     "pretty": true

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -3,6 +3,6 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: ["src/index.ts"],
   splitting: false,
-  sourcemap: true,
+  sourcemap: false,
   target: "es2018",
 });


### PR DESCRIPTION
## Summary

Excludes source map generation files.

### Test plan

- [ ] run `npm publish --dry-run`, output:

```cmd
npm notice 
npm notice 📦  @exodus/aptos-sdk-fork@1.19.4-exodus.1
npm notice === Tarball Contents === 
npm notice 10.9kB LICENSE        
npm notice 486B   README.md      
npm notice 65.6kB dist/index.d.ts
npm notice 81.3kB dist/index.js  
npm notice 1.7kB  package.json   
npm notice === Tarball Details === 
npm notice name:          @exodus/aptos-sdk-fork                    
npm notice version:       1.19.4-exodus.1                           
npm notice filename:      @exodus/aptos-sdk-fork-1.19.4-exodus.1.tgz
npm notice package size:  44.3 kB                                   
npm notice unpacked size: 239.4 kB                                  
npm notice shasum:        6703479b055171e8e46b8430f85d2776301cc7d8  
npm notice integrity:     sha512-cJulrJVVyIMau[...]xlYLtiX6vKwOA==  
npm notice total files:   6                                         
npm notice 
npm notice Publishing to https://registry.npmjs.org/ (dry-run)
+ @exodus/aptos-sdk-fork@1.19.4-exodus.1
```
