### PR TITLE
fix(memoize-decorator): remove weak arg concatenation logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,5 @@
     "typedoc": "^0.23.20",
     "typescript": "4.8.2"
   },
-  "version": "1.19.4-exodus.1"
+  "version": "1.19.4-exodus.2"
 }

--- a/src/utils/memoize-decorator.ts
+++ b/src/utils/memoize-decorator.ts
@@ -2,6 +2,8 @@
  * Credits to https://github.com/darrylhodgins/typescript-memoize
  */
 
+import assert from "assert";
+
 /* eslint-disable no-param-reassign */
 /* eslint-disable no-restricted-syntax */
 
@@ -107,7 +109,7 @@ function getNewFunction(
 
       // If true is passed as first parameter, will automatically use every argument, passed to string
       if (hashFunction === true) {
-        hashKey = args.map((a) => a.toString()).join("!");
+        assert(args.length === 0, "Memoize is not allowed to receive arguments")
       } else if (hashFunction) {
         hashKey = hashFunction.apply(that, args);
       } else {


### PR DESCRIPTION
Prevents `@Memoize` decorator to use arguments

[Slack thread](https://exodusio.slack.com/archives/C02BRG0AY3Z/p1700680475926069?thread_ts=1700654673.668279&cid=C02BRG0AY3Z)